### PR TITLE
Change the select statement for devices

### DIFF
--- a/server/inc/API.php
+++ b/server/inc/API.php
@@ -407,7 +407,7 @@ class API
 	public function devices(): array
 	{
 		if ($this->method === 'GET') {
-			return $this->queryWithData('SELECT * FROM devices WHERE user = ?;', $this->user->id);
+			return $this->queryWithData('SELECT deviceid as id, user, deviceid, name, data FROM devices WHERE user = ?;', $this->user->id);
 		}
 
 		if ($this->method === 'POST') {


### PR DESCRIPTION
When you select a current device in AntennaPod it uses the ID
![image](https://github.com/kd2org/opodsync/assets/26516524/88c86915-7b9f-4d3a-82e3-080257d840c6)

The actual ID should be like it was before the current selection
![image](https://github.com/kd2org/opodsync/assets/26516524/dde0f938-a091-4ee1-9d6e-595ec238262f)

This change puts deviceid as 'id', when the existing device is selected AntennaPod uses the correct id
![image](https://github.com/kd2org/opodsync/assets/26516524/f97ab973-0608-4e19-a062-bbbc26b2ccc7)
