### PR TITLE
Make it possible for users to disable token authentication via config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ const BASE_URL = 'https://gpodder.mydomain.tld/me/';
 // as this may add some load on your server
 // (default is FALSE)
 const DISABLE_USER_METADATA_UPDATE = true;
+
+// Disable passwordless, token-based authentication.
+// This is intended to support GPodder desktop which does not support passwords.
+// If you don't need this support, it may be a bit of a security issue to leave on,
+// so you may turn it off here:
+const DISABLE_TOKEN_AUTHENTICATION = true;
 ```
 
 ### Fetching and updating feeds metadata
@@ -111,6 +117,8 @@ gPodder (the [desktop client](https://gpodder.github.io), not the gpodder.net se
 This means that you have to use a unique secret token as the username.
 
 This token is displayed when you log in. Use it as the username in gPodder configuration.
+
+If you don't need this type of authentication, set `DISABLE_TOKEN_AUTHENTICATION` to true in `config.local.php`.
 
 ## APIs
 

--- a/server/inc/GPodder.php
+++ b/server/inc/GPodder.php
@@ -60,6 +60,10 @@ class GPodder
 
 	public function validateToken(string $username): bool
 	{
+		if (DISABLE_TOKEN_AUTHENTICATION) {
+			return false;
+		}
+
 		$login = strtok($username, '__');
 		$token = strtok('');
 

--- a/server/index.php
+++ b/server/index.php
@@ -79,6 +79,10 @@ if (!defined('DISABLE_USER_METADATA_UPDATE')) {
 	define('DISABLE_USER_METADATA_UPDATE', false);
 }
 
+if (!defined('DISABLE_TOKEN_AUTHENTICATION')) {
+	define('DISABLE_TOKEN_AUTHENTICATION', false);
+}
+
 $db = new DB(DATA_ROOT . '/data.sqlite');
 $api = new API($db);
 
@@ -226,8 +230,10 @@ elseif ($gpodder->user) {
 
 	echo '<p class="center"><img src="icon.svg" width="150" alt="" /></p>';
 	printf('<h2 class="center">Logged in as %s</h2>', $gpodder->user->name);
-	printf('<h3 class="center">GPodder secret username: %s</h2>', $gpodder->getUserToken());
-	echo '<p class="center"><small>(Use this username in GPodder desktop, as it does not support passwords.)</small></p>';
+	if (!DISABLE_TOKEN_AUTHENTICATION) {
+		printf('<h3 class="center">GPodder secret username: %s</h2>', $gpodder->getUserToken());
+		echo '<p class="center"><small>(Use this username in GPodder desktop, as it does not support passwords.)</small></p>';
+	}
 	printf('<p class="center">You have %d active subscriptions.</p><p class="center"><a href="subscriptions" class="btn sm">List my subscriptions</a></p>', $gpodder->countActiveSubscriptions());
 
 	echo '<p class="center"><a href="logout" class="btn sm">Logout</a></p>';


### PR DESCRIPTION
Thanks for making this app to make it easier to self-host.

I have no need to use GPodder desktop and it seems more secure to disable the "token authentication" scheme in the case where it's not needed. This PR adds a `DISABLE_TOKEN_AUTHENTICATION` flag to `config.local.php` to allow users to disable this authentication scheme. It defaults to the previous behavior (token scheme is enabled by default.)