### PR TITLE
Fix check if BASE_URL is defined

### DIFF
--- a/server/lib/OPodSync/API.php
+++ b/server/lib/OPodSync/API.php
@@ -18,7 +18,7 @@ class API
 
 	public function __construct()
 	{
-		$url = defined('BASE_URL') ? BASE_URL : null;
+		$url = defined(__NAMESPACE__ . '\\BASE_URL') ? BASE_URL : null;
 		$url ??= getenv('BASE_URL', true) ?: null;
 
 		if (!$url) {


### PR DESCRIPTION
defined does not honor the current namespace and you always have to use the full quallified name of the constant.