### PR TITLE
Hide 'create account' button when signups are disabled

### DIFF
--- a/server/index.php
+++ b/server/index.php
@@ -49,6 +49,7 @@ if ($gpodder->user) {
 	$tpl->display('index_logged.tpl');
 }
 else {
+	$tpl->assign('canSubscribe', $gpodder->canSubscribe());
 	$tpl->display('index.tpl');
 }
 

--- a/server/templates/index.tpl
+++ b/server/templates/index.tpl
@@ -6,7 +6,9 @@
 
 <p class="center">
 	<a href="login.php" class="btn">Login</a>
+{if $canSubscribe}
 	<a href="register.php" class="btn">Create account</a>
+{/if}
 </p>
 
 {include file="_foot.tpl"}


### PR DESCRIPTION
Hides the 'Create account' button when signup is disabled.

<img width="1282" height="689" alt="image" src="https://github.com/user-attachments/assets/7d900af9-b874-41b7-8c00-988fbc3827c1" />

```
$defaults = [
	'ENABLE_SUBSCRIPTIONS'         => true,
	//...
];
```

... in `_inc.php` turns it back on:

<img width="1282" height="689" alt="image" src="https://github.com/user-attachments/assets/d6625f9c-e6f9-43da-bcb2-9d4262c4c715" />
