### PR TITLE
Return HTTP 401 when using wrong credentials on login page

### DIFF
--- a/server/login.php
+++ b/server/login.php
@@ -13,6 +13,10 @@ if (isset($_GET['logout'])) {
 $token = isset($_GET['token']) ? '?oktoken' : '';
 $error = $gpodder->login();
 
+if ($error) {
+    http_response_code(401);
+}
+
 if ($gpodder->isLogged()) {
 	header('Location: ./' . $token);
 	exit;


### PR DESCRIPTION
I have my opodsync exposed via a reverse proxy and want to track (and block) failed logins. Changed `login.php` so it returns a `401` response (previously `200`) upon invalid credentials. Hope you find this useful.

<img width="1364" height="749" alt="image" src="https://github.com/user-attachments/assets/abebc638-4581-4186-83ea-6464d2762a6b" />
