### PR TITLE
Fix api outputs

### DIFF
--- a/server/lib/OPodSync/API.php
+++ b/server/lib/OPodSync/API.php
@@ -365,7 +365,7 @@ class API
 			exit;
 		}
 
-		if (!preg_match('!api(?:/|$)!', $this->url)) {
+		if (!preg_match('!^(?:api(?:/|$)|subscriptions/|suggestions/|toplist/)!', $this->url)) {
         	return;
 		}
 

--- a/server/lib/OPodSync/API.php
+++ b/server/lib/OPodSync/API.php
@@ -365,8 +365,12 @@ class API
 			exit;
 		}
 
+		if (!preg_match('!api(?:/|$)!', $this->url)) {
+        	return;
+		}
+
 		if (!preg_match('!^(suggestions|subscriptions|toplist|api/2/(auth|subscriptions|devices|updates|episodes|favorites|settings|lists|sync-devices|tags?|data))/!', $this->url, $match)) {
-			return;
+			$this->error(400, 'Unknown or malformed API request');
 		}
 
 		$this->section = $match[2] ?? $match[1];


### PR DESCRIPTION
Part 2 of #75. Noticed that calling invalid API endpoints did not return an error but rather an unformatted home page. Adjusted `API.php` to my needs.