### PR TITLE
Fixed a minor link with missing .php

### DIFF
--- a/server/templates/feed.tpl
+++ b/server/templates/feed.tpl
@@ -1,7 +1,7 @@
 {include file="_head.tpl"}
 
 <p class="center">
-	<a href="./subscriptions" class="btn sm" aria-label="Go Back">&larr; Back</a>
+	<a href="./subscriptions.php" class="btn sm" aria-label="Go Back">&larr; Back</a>
 </p>
 
 {if isset($feed->url, $feed->title, $feed->description)}


### PR DESCRIPTION
The `Back` button in `feed.php` was redirecting to `subscriptions` and not `subscriptions.php` when all other links do. It breaks use in minimal configurations which are not trying to append `.php` to links (including default `nginx` configuration)