### PR TITLE
Added reference to another docker image in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ If you want to allow more accounts, you'll have to configure the server (see "Co
 
 ### Docker
 
-There is an unofficial [Docker image available](https://hub.docker.com/r/ganeshlab/opodsync). Please report any Docker issue [there](https://github.com/ganeshlab/opodsync).
+There a some unofficial Docker images available.  
+ * [opodsync](https://hub.docker.com/r/ganeshlab/opodsync). Please report any Docker issue [there](https://github.com/ganeshlab/opodsync).
+ * [opodsync_dckr](https://hub.docker.com/r/billznn/opodsync_dckr): downloads from oPodSync upstream when building the container (not forking); [source](https://github.com/mzannoni/opodsync_dckr).
 
-If this image stops being maintained, see [Docker Hub](https://hub.docker.com/search?q=opodsync) to find other community distribution for Docker.
+If these images stop being maintained, see [Docker Hub](https://hub.docker.com/search?q=opodsync) to find other community distribution for Docker.
 
 **Please don't report Docker issues here, this repository is only for software development.**
 


### PR DESCRIPTION
Unlike the currently mentioned unofficial Docker image (which forks the repo and adds a Dockerfile), this new image does not touch the oPodSync source at all — it downloads it directly from this repo at build time. This means it stays cleanly in sync with upstream: rebuilding the image is all that's needed to pick up any updates.

Suggestion to close issue #88.