### PR TITLE
Fix CLI invocation crashing on missing $_SERVER keys

### DIFF
--- a/server/_inc.php
+++ b/server/_inc.php
@@ -43,7 +43,7 @@ $defaults = [
 	'ERRORS_REPORT_URL'            => null,
 	'TITLE'                        => 'My oPodSync server',
 	'DEBUG_LOG'                    => null,
-	'HTTP_SCHEME'                  => !empty($_SERVER['HTTPS']) || $_SERVER['SERVER_PORT'] == 443 ? 'https' : 'http',
+	'HTTP_SCHEME'                  => !empty($_SERVER['HTTPS']) || ($_SERVER['SERVER_PORT'] ?? null) == 443 ? 'https' : 'http',
 ];
 
 foreach ($defaults as $const => $value) {
@@ -73,8 +73,9 @@ foreach ($defaults as $const => $value) {
 }
 
 if (!defined(__NAMESPACE__ . '\BASE_URL')) {
-	$name = $_SERVER['SERVER_NAME'];
-	$port = !in_array($_SERVER['SERVER_PORT'], [80, 443]) ? ':' . $_SERVER['SERVER_PORT'] : '';
+	$name = $_SERVER['SERVER_NAME'] ?? 'localhost';
+	$server_port = $_SERVER['SERVER_PORT'] ?? null;
+	$port = $server_port && !in_array($server_port, [80, 443]) ? ':' . $server_port : '';
 	$root = '/';
 
 	define(__NAMESPACE__ . '\BASE_URL', sprintf('%s://%s%s%s', HTTP_SCHEME, $name, $port, $root));

--- a/server/index.php
+++ b/server/index.php
@@ -2,7 +2,7 @@
 
 namespace OPodSync;
 
-$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+$uri = parse_url($_SERVER['REQUEST_URI'] ?? '', PHP_URL_PATH);
 
 // Stop here if we are using CLI server and the requested resource exists,
 // it will be served by PHP HTTP server


### PR DESCRIPTION
Running `php server/index.php` directly (e.g. for the cron feed-update path guarded by `PHP_SAPI === 'cli'`) crashed on `REQUEST_URI`, `SERVER_PORT` and `SERVER_NAME` — `$_SERVER` keys that only exist under a web server.

This guards those three accesses with sensible fallbacks so the CLI path runs cleanly while web-server behaviour is unchanged (the guards only kick in when the keys are absent):

- `index.php` — default `REQUEST_URI` to `''`
- `_inc.php` — null-coalesce `SERVER_PORT` in the `HTTP_SCHEME` check
- `_inc.php` — fall back to `localhost` / no port when building `BASE_URL`

Note: for real CLI feed-update use you'd normally set `BASE_URL` in `config.local.php`; the `localhost` fallback just prevents a fatal when it isn't set.

Fixes #95