### PR TITLE
Make DB_QUERY_RUNNING_TIME_LIMIT configurable for database query execution time

### DIFF
--- a/config.dist.php
+++ b/config.dist.php
@@ -158,3 +158,13 @@ const ERRORS_REPORT_URL = null;
  * @var string|null
  */
 const DEBUG_LOG = DATA_ROOT . '/debug.log';
+
+/**
+ * DB_QUERY_RUNNING_TIME_LIMIT
+ * Set the maximum time in seconds a database query is allowed to run.
+ * If a query takes longer than this, it will be aborted and an error will be returned
+ *
+ * Default: 30
+ * @var int
+ */
+const DB_QUERY_RUNNING_TIME_LIMIT = 30;

--- a/server/_inc.php
+++ b/server/_inc.php
@@ -44,6 +44,7 @@ $defaults = [
 	'TITLE'                        => 'My oPodSync server',
 	'DEBUG_LOG'                    => null,
 	'HTTP_SCHEME'                  => !empty($_SERVER['HTTPS']) || $_SERVER['SERVER_PORT'] == 443 ? 'https' : 'http',
+	'DB_QUERY_RUNNING_TIME_LIMIT'  => 30,
 ];
 
 foreach ($defaults as $const => $value) {

--- a/server/lib/OPodSync/GPodder.php
+++ b/server/lib/OPodSync/GPodder.php
@@ -362,7 +362,7 @@ class GPodder
 		$db = DB::getInstance();
 
 		foreach ($db->iterate($sql) as $row) {
-			@set_time_limit(30); // Extend running time;
+			@set_time_limit(DB_QUERY_RUNNING_TIME_LIMIT); // Extend running time;
 
 			if ($cli) {
 				printf("Updating %s\n", $row->url);


### PR DESCRIPTION
Some of my feeds take more than 30 seconds to update, instead of simply patching the file or just bumping it to an arbitrarily high value, I suggest we make this explicit via a configuration option that defaults to the current value of 30 seconds.